### PR TITLE
Makefile: add support for git svn clones

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,9 @@ top_builddir = .
 
 include $(top_builddir)/Makeconf
 
+GIT := $(shell if [ -d "$(top_builddir)/.git" ]; then \
+	echo "git"; fi)
+
 distdir = $(PACKAGE)-$(VERSION)
 INSTFILES = COPYING
 NON_SVN_INSTFILES = SVN-REVISION
@@ -104,7 +107,7 @@ svnonly:
 	@if test ! -f "$(srcdir)/doc/FAQ" || test -f non-tarball ; then \
 	  (cd doc/manual && $(MAKE) front-matter html-non-svn) ; \
 	  touch non-tarball ; \
-	  (cd $(srcdir); LC_ALL=C TZ=GMT svn info || $(ECHO) "Revision: -99") 2> /dev/null \
+	  (cd $(srcdir); LC_ALL=C TZ=GMT $(GIT) svn info || $(ECHO) "Revision: -99") 2> /dev/null \
 	    | sed -n -e '/^Revision/p' -e '/^Last Changed Date/'p \
 	    | cut -d' ' -f1,2,3,4 > SVN-REVISION-tmp ; \
 	  if test "`cat SVN-REVISION-tmp`" = "Revision: -99"; then \


### PR DESCRIPTION
git has an interface for cloning SVN repositories into git which
some users might decide to use. For those users' surprise, the
repository will always fail to build on svnonly target and it will
exit early.

The problem is simple enough to fix by just checking if a .git
directory exists in top_builddir and, if so, call git svn info insstead
of svn info.

Note that currently, this only works with Linux (and possibly Mac)
because I don't have any means for writing a similar patch for
Windows makefiles.

Signed-off-by: Felipe Balbi <balbi@kernel.org>