### PR TITLE
Update sink.R

### DIFF
--- a/src/library/base/R/sink.R
+++ b/src/library/base/R/sink.R
@@ -16,7 +16,7 @@
 #  A copy of the GNU General Public License is available at
 #  http://www.r-project.org/Licenses/
 
-sink <- function(file=NULL, append = FALSE, type = c("output", "message"),
+sink <- function(file=NULL, append = FALSE, type = "output",
                  split=FALSE)
 {
     type <- match.arg(type)


### PR DESCRIPTION
The default value of type is a character _vector_ but implementation assumes a single character value. This is very confusing from an interface perspective as the client code would assume by default both message and output are redirected. Proposing to change the default arg to one character value instead.