### PR TITLE
Adding the GC trigger

### DIFF
--- a/src/include/Internal.h
+++ b/src/include/Internal.h
@@ -443,6 +443,7 @@ SEXP do_unlink(SEXP, SEXP, SEXP, SEXP);
 SEXP do_unlist(SEXP, SEXP, SEXP, SEXP);
 SEXP do_unserializeFromConn(SEXP, SEXP, SEXP, SEXP);
 SEXP do_unsetenv(SEXP, SEXP, SEXP, SEXP);
+SEXP do_usedVSizeTrigger(SEXP, SEXP, SEXP, SEXP);
 SEXP NORET do_usemethod(SEXP, SEXP, SEXP, SEXP);
 SEXP do_utf8ToInt(SEXP, SEXP, SEXP, SEXP);
 SEXP do_validEnc(SEXP, SEXP, SEXP, SEXP);

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -701,6 +701,7 @@ FUNTAB R_FunTab[] =
 {"memory.profile",do_memoryprofile, 0,	11,	0,	{PP_FUNCALL, PREC_FN,	0}},
 {"mem.maxVSize",do_maxVSize,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
 {"mem.maxNSize",do_maxNSize,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
+{"mem.usedVSizeTrigger",do_usedVSizeTrigger,   0,      11,     1,      {PP_FUNCALL, PREC_FN,   0}},
 {"split",	do_split,	0,	11,	2,	{PP_FUNCALL, PREC_FN,	0}},
 {"is.loaded",	do_isloaded,	0,	11,	-1,	{PP_FOREIGN, PREC_FN,	0}},
 {"recordGraphics", do_recordGraphics, 0, 211,   3,      {PP_FOREIGN, PREC_FN,	0}},


### PR DESCRIPTION
@lawremi

Works like this:

```r
.Internal(mem.usedVSizeTrigger(1000)) # Set at 1 GB.
.Internal(mem.usedVSizeTrigger(Inf)) # unset
```

Test rig is here:

```r
x <- runif(1e8)

stats <- gc()
stats["Vcells","used"] * 8 / 1e9 # just over 0.8 GB in use, which makes sense.
stats["Vcells","gc trigger"] * 8 / 1e9 # gc triggered at 1.18 GB... okay.

library(parallel)
out <- mclapply(1:10, function(i) {
   .Internal(mem.usedVSizeTrigger(1100)) # Set at 1.1 GB.
    for (i in seq_len(20)) {
        current <- runif(1e7)
        y <- current + 1
    }
    gc()
}, mc.cores=10)

stats <- out[[1]]
stats["Vcells","used"] * 8 / 1e9 # 0.96 GB in use, which makes sense (0.8 + 0.08 + 0.08).
stats["Vcells","max used"] * 8 / 1e9 # but max used goes past our trigger
```

If the GC is being triggered correctly, the loops should never use more than ~1.06 GB per worker.