### PR TITLE
Set reorder = FALSE in rowsum()

### DIFF
--- a/src/library/base/R/rowsum.R
+++ b/src/library/base/R/rowsum.R
@@ -16,9 +16,9 @@
 #  A copy of the GNU General Public License is available at
 #  https://www.R-project.org/Licenses/
 
-rowsum <- function(x, group, reorder = TRUE, ...) UseMethod("rowsum")
+rowsum <- function(x, group, reorder = FALSE, ...) UseMethod("rowsum")
 
-rowsum.default <- function(x, group, reorder = TRUE, na.rm = FALSE, ...)
+rowsum.default <- function(x, group, reorder = FALSE, na.rm = FALSE, ...)
 {
     if (!is.numeric(x)) stop("'x' must be numeric")
     if (length(group) != NROW(x)) stop("incorrect length for 'group'")
@@ -29,7 +29,7 @@ rowsum.default <- function(x, group, reorder = TRUE, na.rm = FALSE, ...)
     .Internal(rowsum_matrix(x, group, ugroup, na.rm, as.character(ugroup)))
 }
 
-rowsum.data.frame <- function(x, group, reorder = TRUE, na.rm = FALSE, ...)
+rowsum.data.frame <- function(x, group, reorder = FALSE, na.rm = FALSE, ...)
 {
     if (!is.data.frame(x)) stop("not a data frame") ## make MM happy
     if (length(group) != NROW(x)) stop("incorrect length for 'group'")


### PR DESCRIPTION
I am not sure if I am following the correct steps to make a suggestion to base R functions, but this PR is a suggestion to set the default `reorder` argument in `rowsum()` to `reorder = FALSE`. The current default of `reorder = TRUE` seems like a poor choice. If the user is handing `rowsum()` a grouping vector, I would assume the user has set the grouping vector in the desired order by which they want to compute row-wise sums. If they wanted the grouping vector to be reordered prior to computing the row-wise sum, I expect that would be the exception rather than the rule, in which case they would set `reorder = TRUE`.