### PR TITLE
add missing `AC_CONFIG_MACRO_DIR(m4)` aclocal macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@
 ### https://www.r-project.org/Licenses/
 
 AC_PREREQ(2.69)
+AC_CONFIG_MACRO_DIR([m4])
 
 ## We want to get the version number from file 'VERSION' (rather than
 ## specifying the version info in 'configure.ac'.  Hence, we need a bit


### PR DESCRIPTION
Without that patch is not possible to initialize source tree using standard `autoreconf -fiv`.
Missiang AC_CONFIG_MACRO_DIR(m4) call adds path to project local aclocal macros.